### PR TITLE
[maven-release-plugin] Maven release

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,4 +2,5 @@ name: okdp-spark-auth-filter
 release:
   current-version: 0.0.3-RC1
   next-version: 0.0.3-SNAPSHOT
+#
 


### PR DESCRIPTION
Maven release
- Prepare release 0.0.3-RC1
- Publish to [Maven central repository][1]
- Prepare for next development iteration 0.0.3-SNAPSHOT

[1]: https://central.sonatype.com/artifact/io.okdp/okdp-spark-auth-filter/overview