### PR TITLE
[maven-release-plugin] Maven release

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,5 +2,5 @@ name: okdp-spark-auth-filter
 release:
   current-version: 0.0.3-RC1
   next-version: 0.0.3-SNAPSHOT
-####
+#####
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,5 +2,5 @@ name: okdp-spark-auth-filter
 release:
   current-version: 0.0.3-RC1
   next-version: 0.0.3-SNAPSHOT
-###
+####
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,5 +2,5 @@ name: okdp-spark-auth-filter
 release:
   current-version: 0.0.3-RC1
   next-version: 0.0.3-SNAPSHOT
-#####
+####
 

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -94,10 +94,12 @@ jobs:
           body: |
             Maven release:
             - Prepare release ${{ fromJSON(steps.release.outputs.result).current-version }} (see below the list of changes)
+            - Create release tag [][2]
             - Publish to [Maven central repository][1]
             - Prepare for next development iteration ${{ fromJSON(steps.release.outputs.result).next-version }}
             
             [1]: https://central.sonatype.com/artifact/io.okdp/okdp-spark-auth-filter/overview
+            [2]: https://central.sonatype.com/artifact/io.okdp/okdp-spark-auth-filter/overview
           #team-reviewers: reviewers
           labels: |
             maven-release

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -93,13 +93,13 @@ jobs:
           title: '[maven-release-plugin] Maven release'
           body: |
             Maven release:
-            - Prepare release ${{ fromJSON(steps.release.outputs.result).current-version }} (see below the list of changes)
-            - Create release tag [][2]
+            - Prepare release v${{ fromJSON(steps.release.outputs.result).current-version }} (see below the list of changes)
+            - Create release tag [v${{ fromJSON(steps.release.outputs.result).current-version }}][2]
             - Publish to [Maven central repository][1]
             - Prepare for next development iteration ${{ fromJSON(steps.release.outputs.result).next-version }}
             
             [1]: https://central.sonatype.com/artifact/io.okdp/okdp-spark-auth-filter/overview
-            [2]: https://central.sonatype.com/artifact/io.okdp/okdp-spark-auth-filter/overview
+            [2]: https://github.com/okdp/okdp-spark-auth-filter/tree/v${{ fromJSON(steps.release.outputs.result).current-version }}
           #team-reviewers: reviewers
           labels: |
             maven-release

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,10 +1,10 @@
 name: Release [publish]
 
 on:
-  pull_request:
+  pull_request_review:
+    types: [submitted]
     branches:
       - main
-    types: [closed]
     paths:
       - '.github/release.yml'
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.github.idirze</groupId>
   <artifactId>kdp-spark-auth-filter</artifactId>
-  <version>0.0.3-SNAPSHOT</version>
+  <version>0.0.3-RC1</version>
   <!-- <groupId>io.okdp</groupId>-->
   <!-- <artifactId>okdp-spark-auth-filter</artifactId>-->
   <!--<version>1.0.0</version>-->

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.github.idirze</groupId>
   <artifactId>kdp-spark-auth-filter</artifactId>
-  <version>0.0.3-RC1</version>
+  <version>0.0.3-SNAPSHOT</version>
   <!-- <groupId>io.okdp</groupId>-->
   <!-- <artifactId>okdp-spark-auth-filter</artifactId>-->
   <!--<version>1.0.0</version>-->

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.github.idirze</groupId>
   <artifactId>kdp-spark-auth-filter</artifactId>
-  <version>0.0.3-SNAPSHOT</version>
+  <version>0.0.3-RC1</version>
   <!-- <groupId>io.okdp</groupId>-->
   <!-- <artifactId>okdp-spark-auth-filter</artifactId>-->
   <!--<version>1.0.0</version>-->
@@ -41,7 +41,7 @@
     <connection>scm:git:https://github.com/idirze/okdp-spark-auth-filter.git</connection>
     <developerConnection>scm:git:https://github.com/idirze/okdp-spark-auth-filter.git</developerConnection>
     <url>https://github.com/idirze/okdp-spark-auth-filter.git</url>
-    <tag>v0.0.4</tag>
+    <tag>v0.0.3-RC1</tag>
   </scm>
 
   <organization>


### PR DESCRIPTION
Maven release:
- Prepare release v0.0.3-RC1 (see below the list of changes)
- Create release tag [v0.0.3-RC1][2]
- Publish to [Maven central repository][1]
- Prepare for next development iteration 0.0.3-SNAPSHOT

[1]: https://central.sonatype.com/artifact/io.okdp/okdp-spark-auth-filter/overview
[2]: https://github.com/okdp/okdp-spark-auth-filter/tree/v0.0.3-RC1