### PR TITLE
[maven-release-plugin] Maven release

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,5 +2,5 @@ name: okdp-spark-auth-filter
 release:
   current-version: 0.0.3-RC1
   next-version: 0.0.3-SNAPSHOT
-#####
+######
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,5 +2,5 @@ name: okdp-spark-auth-filter
 release:
   current-version: 0.0.3-RC1
   next-version: 0.0.3-SNAPSHOT
-####
+##
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,5 +2,5 @@ name: okdp-spark-auth-filter
 release:
   current-version: 0.0.3-RC1
   next-version: 0.0.3-SNAPSHOT
-##
+#####
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,8 +1,9 @@
 name: Release [publish]
 
 on:
-  pull_request_review:
-    types: [submitted]
+  pull_request:
+    types:
+      - closed
     branches:
       - main
     paths:
@@ -24,7 +25,7 @@ defaults:
 jobs:
   publish-release:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'idirze' &&  github.event.review.state == 'approved' && contains(github.event.pull_request.labels.*.name, 'maven-release')
+    if: github.repository_owner == 'idirze' && github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'maven-release')
     steps:
       - name: Checkout Repo ⚡️
         uses: actions/checkout@v4


### PR DESCRIPTION
Maven release:
- Prepare release v0.0.3-RC1 (see below the list of changes)
- Create release tag [v0.0.3-RC1][2]
- Publish to [Maven central repository][1]
- Prepare for next development iteration 0.0.3-SNAPSHOT

[1]: https://central.sonatype.com/artifact/io.okdp/okdp-spark-auth-filter/overview
[2]: https://github.com/okdp/okdp-spark-auth-filter/tree/v0.0.3-RC1